### PR TITLE
Add due date support

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders todo app header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/Todo App/i);
+  expect(headerElement).toBeInTheDocument();
 });

--- a/src/components/TodoInput.jsx
+++ b/src/components/TodoInput.jsx
@@ -1,19 +1,28 @@
-import React, { useContext } from "react";
-import { useTask } from "../context/TaskContext";
+import React from "react";
+import { useTask, useTaskDueDate } from "../context/TaskContext";
 
 /**
  * Input component that creates a todo when the user enters a todo title
  */
 export default function TodoInput() {
-  const { taskTitle, setTaskTitle } = useTask(); // Custom hook that returns the task and setTask function from the taskTitle Context
+  const { taskTitle, setTaskTitle } = useTask(); // Custom hook that returns the task title state
+  const { taskDueDate, setTaskDueDate } = useTaskDueDate(); // Custom hook that returns the task due date state
   return (
-    <input
-      value={taskTitle}
-      onChange={(e) => {
-        setTaskTitle(e.target.value);
-      }}
-      className="w-1/3 border-b border-transparent focus:border-white focus:transition-all bg-transparent text-white focus:outline-0"
-      placeholder="Add Task"
-    />
+    <>
+      <input
+        value={taskTitle}
+        onChange={(e) => {
+          setTaskTitle(e.target.value);
+        }}
+        className="w-1/3 border-b border-transparent focus:border-white focus:transition-all bg-transparent text-white focus:outline-0"
+        placeholder="Add Task"
+      />
+      <input
+        type="date"
+        value={taskDueDate}
+        onChange={(e) => setTaskDueDate(e.target.value)}
+        className="ml-2 border rounded bg-transparent text-white focus:outline-0"
+      />
+    </>
   );
 }

--- a/src/components/todoContent/TodoFlexBox.jsx
+++ b/src/components/todoContent/TodoFlexBox.jsx
@@ -88,6 +88,9 @@ function TodoTask({ todo }) {
       >
         {todoTask.title}
       </p>
+      {todoTask.dueDate && (
+        <p className="text-xs text-gray-300">Due: {todoTask.dueDate}</p>
+      )}
       {isModalOpen && ( // Conditional rendering for the modal being open
         <TodoModal
           closeModal={closeModal}
@@ -192,6 +195,9 @@ function TodoModal({
             }}
           >
             <h2 className="text-lg font-bold mb-2">{todoTask.title}</h2>
+            {todoTask.dueDate && (
+              <p className="text-sm text-gray-600">Due: {todoTask.dueDate}</p>
+            )}
           </div>
         )}
         <button onClick={closeModal}>Exit</button>

--- a/src/context/TaskContext.jsx
+++ b/src/context/TaskContext.jsx
@@ -9,7 +9,8 @@ import { v4 as uuidv4 } from "uuid";
 
 // These are contexts for managing different aspects of the todo application
 const TodoContext = createContext(null); // Context created for todos list.
-const TaskTitleContext = createContext(null); // Context created for the created task's state
+const TaskTitleContext = createContext(null); // Context created for the created task's title state
+const TaskDueDateContext = createContext(null); // Context created for the created task's due date state
 const ChangeTaskContext = createContext(null); // Context created for the add, delete, and update tasks
 const UpdateTaskStatusContext = createContext(null); // Context created for the update task completion status
 const TodoListDispatchContext = createContext(null); // Context created for the dispatch method used with useReducer.
@@ -29,6 +30,8 @@ const ACTIONS = {
 export function TaskProvider({ children }) {
   // useState hook for the newly created task's title
   const [taskTitle, setTaskTitle] = useState("");
+  // useState hook for the newly created task's due date
+  const [taskDueDate, setTaskDueDate] = useState("");
   // useReducer hook that manages the state of the todos.  The initial state is from localStorage
   const [todos, dispatch] = useReducer(reducer, getInitialState());
 
@@ -40,8 +43,9 @@ export function TaskProvider({ children }) {
 
   // Function to add a new task to the todos state
   function addTask() {
-    dispatch({ type: ACTIONS.ADD, task: taskTitle });
+    dispatch({ type: ACTIONS.ADD, task: taskTitle, dueDate: taskDueDate });
     setTaskTitle(""); // Clears the task state after it is created
+    setTaskDueDate(""); // Clears the due date after it is created
   }
 
   // Function to delete a task based off the id
@@ -74,13 +78,15 @@ export function TaskProvider({ children }) {
     <TodoListDispatchContext.Provider value={dispatch}>
       <TodoContext.Provider value={{ todos }}>
         <TaskTitleContext.Provider value={{ taskTitle, setTaskTitle }}>
-          <UpdateTaskStatusContext.Provider value={{ updateTaskStatus }}>
-            <ChangeTaskContext.Provider
-              value={{ addTask, deleteTask, updateTaskTitle }}
-            >
-              {children}
-            </ChangeTaskContext.Provider>
-          </UpdateTaskStatusContext.Provider>
+          <TaskDueDateContext.Provider value={{ taskDueDate, setTaskDueDate }}>
+            <UpdateTaskStatusContext.Provider value={{ updateTaskStatus }}>
+              <ChangeTaskContext.Provider
+                value={{ addTask, deleteTask, updateTaskTitle }}
+              >
+                {children}
+              </ChangeTaskContext.Provider>
+            </UpdateTaskStatusContext.Provider>
+          </TaskDueDateContext.Provider>
         </TaskTitleContext.Provider>
       </TodoContext.Provider>
     </TodoListDispatchContext.Provider>
@@ -99,6 +105,11 @@ export function useDispatch() {
 // Custom hook to return the TaskTitleContext
 export function useTask() {
   return useContext(TaskTitleContext);
+}
+
+// Custom hook to return the TaskDueDateContext
+export function useTaskDueDate() {
+  return useContext(TaskDueDateContext);
 }
 
 // Custom hook to return the ChangeTaskContext
@@ -122,7 +133,10 @@ function reducer(todos, action) {
   switch (action.type) {
     // action to add task to todos
     case ACTIONS.ADD: {
-      return [...todos, { id: uuidv4(), title: action.task, status: false }];
+      return [
+        ...todos,
+        { id: uuidv4(), title: action.task, status: false, dueDate: action.dueDate },
+      ];
     }
     // action to delete a task from todos based off of id
     case ACTIONS.DELETE: {


### PR DESCRIPTION
## Summary
- extend task context model with due dates
- include due date input alongside task title
- display due dates in task list and modal
- update unit test to check for header

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68805c451e588331a9c77b3bd40238d7