### PR TITLE
Add task filtering feature

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Todo App header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/Todo App/i);
+  expect(headerElement).toBeInTheDocument();
 });

--- a/src/components/todoContent/FilterButtons.jsx
+++ b/src/components/todoContent/FilterButtons.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { useFilter } from "../../context/TaskContext";
+
+export default function FilterButtons() {
+  const { filter, setFilter } = useFilter();
+
+  return (
+    <div className="flex space-x-2 my-4">
+      <button
+        className={`px-3 py-1 rounded ${filter === "all" ? "bg-blue-500 text-white" : "bg-gray-200"}`}
+        onClick={() => setFilter("all")}
+      >
+        All
+      </button>
+      <button
+        className={`px-3 py-1 rounded ${filter === "active" ? "bg-blue-500 text-white" : "bg-gray-200"}`}
+        onClick={() => setFilter("active")}
+      >
+        Active
+      </button>
+      <button
+        className={`px-3 py-1 rounded ${filter === "completed" ? "bg-blue-500 text-white" : "bg-gray-200"}`}
+        onClick={() => setFilter("completed")}
+      >
+        Completed
+      </button>
+    </div>
+  );
+}

--- a/src/components/todoContent/TodoDisplay.jsx
+++ b/src/components/todoContent/TodoDisplay.jsx
@@ -1,18 +1,18 @@
-import React, { useContext } from "react";
+import React from "react";
 import TodoFlexBox from "./TodoFlexBox";
-import { TodoListContext } from "../../context/TaskContext";
+import FilterButtons from "./FilterButtons";
 
 /**
  *
  * To do display component that displays the todo list in a flexbox
  */
 export default function TodoDisplay() {
-  // const { todoList } = useContext(TodoListContext);
   return (
     <div
       className="flex flex-col justify-center
     items-center w-full relative m-8"
     >
+      <FilterButtons />
       <TodoFlexBox />
       {/* <ul>
         {todoList.map((todo) => (

--- a/src/components/todoContent/TodoFlexBox.jsx
+++ b/src/components/todoContent/TodoFlexBox.jsx
@@ -3,6 +3,7 @@ import {
   useChangeTask,
   useTodos,
   useUpdateTaskStatus,
+  useFilter,
 } from "../../context/TaskContext";
 import {
   DeleteTaskButton,
@@ -14,9 +15,20 @@ import {
  */
 export default function TodoFlexBox() {
   const { todos } = useTodos();
+  const { filter } = useFilter();
+
+  const filteredTodos = todos.filter((todo) => {
+    if (filter === "active") {
+      return !todo.status;
+    } else if (filter === "completed") {
+      return todo.status;
+    }
+    return true;
+  });
+
   return (
     <div className="flex flex-col items-center justify-center w-full">
-      {todos.map((todo) => (
+      {filteredTodos.map((todo) => (
         <TodoTask key={todo.id} todo={todo} />
       ))}
     </div>

--- a/src/context/TaskContext.jsx
+++ b/src/context/TaskContext.jsx
@@ -13,6 +13,7 @@ const TaskTitleContext = createContext(null); // Context created for the created
 const ChangeTaskContext = createContext(null); // Context created for the add, delete, and update tasks
 const UpdateTaskStatusContext = createContext(null); // Context created for the update task completion status
 const TodoListDispatchContext = createContext(null); // Context created for the dispatch method used with useReducer.
+const FilterContext = createContext(null); // Context for controlling task filter
 
 // Action types for useReducer to handle different actions
 const ACTIONS = {
@@ -70,6 +71,8 @@ export function TaskProvider({ children }) {
     });
   }
 
+  const [filter, setFilter] = useState("all");
+
   return (
     <TodoListDispatchContext.Provider value={dispatch}>
       <TodoContext.Provider value={{ todos }}>
@@ -78,7 +81,9 @@ export function TaskProvider({ children }) {
             <ChangeTaskContext.Provider
               value={{ addTask, deleteTask, updateTaskTitle }}
             >
-              {children}
+              <FilterContext.Provider value={{ filter, setFilter }}>
+                {children}
+              </FilterContext.Provider>
             </ChangeTaskContext.Provider>
           </UpdateTaskStatusContext.Provider>
         </TaskTitleContext.Provider>
@@ -109,6 +114,11 @@ export function useChangeTask() {
 // Custom hook to return the UpdateTaskStatusContext
 export function useUpdateTaskStatus() {
   return useContext(UpdateTaskStatusContext);
+}
+
+// Custom hook to access the current filter
+export function useFilter() {
+  return useContext(FilterContext);
 }
 
 // Variable to get the initial todos state from localStorage


### PR DESCRIPTION
## Summary
- enable task filters in context
- add filter buttons for selecting All/Active/Completed
- filter tasks in `TodoFlexBox`
- adjust `TodoDisplay` to show new buttons
- update default test for new UI

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68805a6c01ac8331b66473f744cdde4e